### PR TITLE
Add workflow to delete url issues

### DIFF
--- a/.github/workflows/url_deleter.yml
+++ b/.github/workflows/url_deleter.yml
@@ -1,0 +1,26 @@
+name: URL Deleter
+on:
+  issues:
+    types:
+      - opened
+      - edited
+jobs:
+  moderate:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Moderate issues
+        uses: tachiyomiorg/issue-moderator-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Thanks to https://regex101.com/library/cX0pJ8 and tp https://www.freeformatter.com/json-escape.html
+          auto-close-rules: |
+            [
+              {
+                "type": "title",
+                "regex": "^((([A-Za-z]{3,9}:(?:\\\/\\\/)?)(?:[-;:&=\\+\\$,\\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\\+\\$,\\w]+@)[A-Za-z0-9.-]+)((?:\\\/[\\+~%\\\/.\\w-_]*)?\\??(?:[-\\+=&;%@.\\w_]*)#?(?:[.\\!\\\/\\\\w]*))?)$",
+                "message": "URL does not belong here (#43). Go to https://github.com/nelsontky/gh-pages-url-shortener-db/issues instead"
+              }
+            ]
+          auto-close-ignore-label: do-not-autoclose

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ be reliable. Do proceed at your own risk!_
       1. Format for `GITHUB_ISSUES_LINK`:
          `https://api.github.com/repos/{owner}/{repo}/issues/`
       1. Remember the trailing `/`!
+   1. If you are going to use your forked repo, then delete `url_deleter.yml` in your `.github/workflows` folder or [disable workflow manually](https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#disabling-a-workflow)
 1. Push your changes to your forked repo, and your low cost and cool as heck URL
    shortener will be ready for use!
 


### PR DESCRIPTION
- Idea from this comment by @smac89: https://github.com/nelsontky/gh-pages-url-shortener/issues/43#issuecomment-731888013
- Using [issue-moderator-action by tachiyomiorg](https://github.com/tachiyomiorg/issue-moderator-action)
- [URL regex by Matthew O'Riordan's](https://regex101.com/library/cX0pJ8). Can't find true source page
  - Then regex was json escaped
- When comment is new, workflow should leave a comment explaining where to create issues with urls mentioning #43 issue
- ReadMe has an instruction to disable this workflow, if user gonna use forked repository
- To close, issue title must contain url only, so issues like [87](https://href.li/?https://github.com/nelsontky/gh-pages-url-shortener/issues/87) with title `github.io links fail` shouldn't close

Cons:
- `google.com` kinda links don't work, only `www.google.com`
- If user is stupid enough to reopen - then issue leaves open
  - Why? Just in case If action goes wrong and it will close wrong issue